### PR TITLE
fix leaky file descriptor

### DIFF
--- a/dynamodb.go
+++ b/dynamodb.go
@@ -66,6 +66,8 @@ func (s *Service) Do(action string, body interface{}, a interface{}) error {
 		return err
 	}
 
+	defer resp.Body.Close()
+
 	if status := resp.StatusCode; status != 200 {
 		var e struct {
 			Message string


### PR DESCRIPTION
in the Do function the body is never closed, which causes net/http to keep opening new connections instead of recycling.  this patch prevents that.  cheers.
